### PR TITLE
Preserve held items and support graceful trade-room exits

### DIFF
--- a/frlgsim/mon.py
+++ b/frlgsim/mon.py
@@ -207,6 +207,7 @@ class Mon:
             tail = stats.build_party_tail(to_decrypted(wire))
             if tail is not None:
                 wire = wire[:BOX_SIZE] + tail
+        wire = wire[:85] + b"\xFF" + wire[86:]
         return cls(wire)
 
     @classmethod

--- a/frlgsim/trade.py
+++ b/frlgsim/trade.py
@@ -622,22 +622,22 @@ class TradeEngine:
                         self.log("entry: host emitted READY (0x16) - host is seated; we may sit now")
                         self.info("Host sat down.")
                         break
-        # POST-CANCEL EXIT: once back in the overworld, the host walks to the south exit, confirms leaving,
-        # and broadcasts LINK_KEY_CODE_EXIT_ROOM (0x17) in its held-keys (KeyInterCB_SendExitRoomKey), then
+        # HOST-LED EXIT: the host can walk out before any trade or after returning from a cancelled trade.
+        # It broadcasts LINK_KEY_CODE_EXIT_ROOM (0x17) in its held-keys (KeyInterCB_SendExitRoomKey), then
         # BLOCKS at KeyInterCB_WaitForPlayersToExit ("You will be escorted out of the room. Please wait.")
         # until ALL players are EXITING_ROOM [overworld.c:2962-2981; cable_club.inc TradeCenter_TerminateLink
         # -> ExitLinkRoom]. The host marks US EXITING_ROOM only when WE send our OWN EXIT_ROOM (Handle-
         # LinkPlayerKeyInput case 2751). The seat-phase scan above is gated off (_host_ready), so detect the
-        # host's EXIT_ROOM HERE; the orchestrator then has linkstate emit ours -> AreAllPlayersInLinkState(
+        # host's EXIT_ROOM HERE regardless of trade state; the orchestrator then has linkstate emit ours -> AreAllPlayersInLinkState(
         # EXITING_ROOM) -> CableClub_EventScript_DoLinkRoomExit -> READY_CLOSE_LINK (c=13). (Reference
         # captures: host EXIT_ROOM IN first, joiner EXIT_ROOM OUT ~3.7s later, THEN the host-led CLOSE.)
-        if self._post_cancel_overworld and not self._host_exiting and unwrapped is not None:
+        if not self._host_exiting and unwrapped is not None:
             for _mpid, slot in unwrapped.get("positional", []):
                 r = rfu.parse_slot(slot)
                 if (r and (r["word0"] & 0xFF00) == rfu.SEND_HELD_KEYS
                         and (int.from_bytes(slot[2:4], "little") & 0xFF) == 0x17):
                     self._host_exiting = True
-                    self.log("post-cancel: host emitted EXIT_ROOM (0x17) - it is walking out and waiting "
+                    self.log("host emitted EXIT_ROOM (0x17) - it is walking out and waiting "
                              "for ALL players to exit; respond with our EXIT_ROOM [overworld.c:2962-2981]")
                     self.info("Host is leaving the room...")
                     break

--- a/frlgtrade.py
+++ b/frlgtrade.py
@@ -20,6 +20,7 @@ OFFLINE self-check (replays a captured host stream through the full RX stack - n
 
 import argparse
 import os
+import signal
 import sys
 import time
 
@@ -166,6 +167,18 @@ def run_live(args, lg):
     connect_ticks = 0
     leave_until = None
     close_until = None
+    graceful_interrupt = False
+    interrupt_count = 0
+
+    def on_interrupt(_signum, _frame):
+        nonlocal graceful_interrupt, interrupt_count
+        interrupt_count += 1
+        if interrupt_count == 1:
+            graceful_interrupt = True
+        else:
+            raise KeyboardInterrupt
+
+    old_sigint = signal.signal(signal.SIGINT, on_interrupt)
     # Overworld leave tail: keep the link ALIVE (held-keys keepalive) while waiting for the HOST to lead
     # the walk-out and sever the link itself (graceful). The host's exit is human-paced (walk to the south
     # exit -> confirm-leave prompt -> EXIT_ROOM -> RunTerminateLinkScript -> CloseLink -> 'D'), so this is
@@ -175,6 +188,14 @@ def run_live(args, lg):
     try:
         while True:
             s.tick()
+            if graceful_interrupt:
+                graceful_interrupt = False
+                if engine.host_in_seat and engine.in_seat_phase and lstate is not None:
+                    lstate.exit()
+                    lg("[live] Ctrl+C: sent EXIT_ROOM; waiting for the host to terminate the link. "
+                       "Press Ctrl+C again to stop immediately.")
+                else:
+                    raise KeyboardInterrupt
             # Save each received mon the INSTANT it commits (on CONFIRM_FINISH), not just at graceful
             # run-end: the post-trade tail (save chain / cancel / close) can stall or be Ctrl+C'd, and the
             # mon data is already valid at commit. Writing here means the received mon survives an
@@ -291,6 +312,7 @@ def run_live(args, lg):
                 break
             time.sleep(period)
     finally:
+        signal.signal(signal.SIGINT, old_sigint)
         s.close()          # flush the --capture .jsonl
         t.stop()
         lg.info("Link closed.")


### PR DESCRIPTION
## Originating Issues

- Held items appeared in the trade window but disappeared after the trade completed.
- A trade session could not be ended early without abruptly breaking the connection. Cancelling from the Switch was not handled, and stopping the simulator could cause a Communication Error on the Switch.

## Preserve held items after a trade

The simulator now marks offered Pokémon as having no attached mail while preserving their held-item data.

FireRed and LeafGreen treat the Pokémon’s mail field as an index into the partner’s transferred mail records. After swapping the Pokémon, [the trade routine attaches the referenced mail record](https://github.com/pret/pokefirered/blob/c75f352304d529f6ba92d4f74b9cf8b5c3810788/src/trade_scene.c#L1054-L1080). The simulator does not transfer mail records, so a stale mail index could cause the game to replace the held item after the trade. This explains why the item appeared in the trade window but disappeared after completion.

Marking the Pokémon as having no mail keeps the party data consistent with the simulator’s empty mail block. Ordinary held items now survive the trade. Actual mail attachments remain unsupported.

## Allow either side to exit gracefully

The simulator now recognizes the Switch’s `EXIT_ROOM` signal throughout the room session. Previously, it only checked for this signal after a cancelled trade. The Switch can now leave before completing a trade, and the simulator responds with its own exit signal.

During a live room or overworld phase, the first Ctrl+C asks the simulator to leave through the same protocol. It sends `EXIT_ROOM` and waits for the Switch to terminate the link. A second Ctrl+C stops the process immediately.

[FireRed’s room-exit logic](https://github.com/pret/pokefirered/blob/c75f352304d529f6ba92d4f74b9cf8b5c3810788/src/overworld.c#L2962-L2981) waits for both players to enter the exiting state before closing the link. Completing that handshake allows either side to end the session without causing a Communication Error on the Switch.

## Verification

- Completed multiple full trade sessions and confirmed that held items transfer successfully.
- Repeatedly initiated exits from both the Switch and the simulator. In both directions, the other side exited gracefully without a Communication Error.
